### PR TITLE
Add "acg.tv" to `whitelist`

### DIFF
--- a/whitelist.pac
+++ b/whitelist.pac
@@ -9571,6 +9571,7 @@ var white_domains = {"am":{
 "9555":1,
 "9928":1,
 "9998":1,
+"acg":1,
 "bilibili":1,
 "caoxian":1,
 "cnnl":1,


### PR DESCRIPTION
Add "acg.tv" to `whitelist` which may cause copyright problem on "bilibili.com".