### PR TITLE
Fix FoxyProxy warning described in issue #8

### DIFF
--- a/whitelist.pac
+++ b/whitelist.pac
@@ -1,4 +1,4 @@
-var wall_proxy = "SOCKS5 127.0.0.1:1080";
+var wall_proxy = "SOCKS5 127.0.0.1:1080; SOCKS 127.0.0.1:1080;";
 var nowall_proxy = "DIRECT;";
 var direct = "DIRECT;";
 var ip_proxy = "DIRECT;";

--- a/whitelist.pac
+++ b/whitelist.pac
@@ -1,4 +1,4 @@
-var wall_proxy = "SOCKS5 127.0.0.1:1080; SOCKS 127.0.0.1:1080;";
+var wall_proxy = "SOCKS5 127.0.0.1:1080";
 var nowall_proxy = "DIRECT;";
 var direct = "DIRECT;";
 var ip_proxy = "DIRECT;";
@@ -9683,6 +9683,8 @@ function isInDomains(domain_dict, host) {
 	}
 }
 function FindProxyForURL(url, host) {
+	url=""+url;
+	host=""+host;
 	if ( isPlainHostName(host) === true ) {
 		return direct;
 	}


### PR DESCRIPTION
I don't know why this works since I don't know how to debug inside foxyproxy. However it seems that url and host are not actually string type, so everything looks like abnormal. Converting them into strings will kill those warnings.